### PR TITLE
sendMail capability

### DIFF
--- a/GraphClient.go
+++ b/GraphClient.go
@@ -5,7 +5,6 @@ package msgraph
 
 import (
 	"bytes"
-	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -233,57 +232,6 @@ func (g *GraphClient) GetGroup(groupID string) (Group, error) {
 	group := Group{graphClient: g}
 	err := g.makeGETAPICall(resource, nil, &group)
 	return group, err
-}
-
-type Mail struct {
-	Message Message `json:"message"`
-}
-
-type Message struct {
-	ToRecipients  []Recipient `json:"toRecipients"`
-	CCRecipients  []Recipient `json:"ccRecipients"`
-	BCCRecipients []Recipient `json:"bccRecipients"`
-	Subject       string      `json:"subject"`
-	Body          Body        `json:"body"`
-}
-
-type Recipient struct {
-	EmailAddress EmailAddress `json:"emailAddress"`
-}
-
-type Body struct {
-	ContentType string `json:"contentType"`
-	Content     string `json:"content"`
-}
-
-// SendMailJSON performs a JSON-based sendMail request
-func (g *GraphClient) SendMailJSON(from string, SendMail Mail) error {
-	resource := fmt.Sprintf("/users/%v/sendMail", url.PathEscape(from))
-
-	if SendMail.Message.BCCRecipients == nil {
-		SendMail.Message.BCCRecipients = []Recipient{}
-	}
-	if SendMail.Message.CCRecipients == nil {
-		SendMail.Message.CCRecipients = []Recipient{}
-	}
-
-	data, err := json.Marshal(SendMail)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	dataStr := string(data)
-
-	err = g.makePOSTAPICall(resource, "application/json", dataStr, nil)
-	return err
-}
-
-// SendMailMIME performs a text/plain (in MIME format) sendMail request
-func (g *GraphClient) SendMailMIME(from string, data []byte) error {
-	resource := fmt.Sprintf("/users/%v/sendMail", url.PathEscape(from))
-	datab64 := b64.StdEncoding.EncodeToString(data)
-	err := g.makePOSTAPICall(resource, "text/plain", datab64, nil)
-	return err
 }
 
 // UnmarshalJSON implements the json unmarshal to be used by the json-library.

--- a/Mail.go
+++ b/Mail.go
@@ -1,0 +1,60 @@
+package msgraph
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	b64 "encoding/base64"
+)
+
+type Mail struct {
+	Message Message `json:"message"`
+}
+
+type Message struct {
+	ToRecipients  []Recipient `json:"toRecipients"`
+	CCRecipients  []Recipient `json:"ccRecipients"`
+	BCCRecipients []Recipient `json:"bccRecipients"`
+	Subject       string      `json:"subject"`
+	Body          Body        `json:"body"`
+}
+
+type Recipient struct {
+	EmailAddress EmailAddress `json:"emailAddress"`
+}
+
+type Body struct {
+	ContentType string `json:"contentType"`
+	Content     string `json:"content"`
+}
+
+// SendMailJSON performs a JSON-based sendMail request
+func (g *GraphClient) SendMailJSON(from string, SendMail Mail) error {
+	resource := fmt.Sprintf("/users/%v/sendMail", url.PathEscape(from))
+
+	if SendMail.Message.BCCRecipients == nil {
+		SendMail.Message.BCCRecipients = []Recipient{}
+	}
+	if SendMail.Message.CCRecipients == nil {
+		SendMail.Message.CCRecipients = []Recipient{}
+	}
+
+	data, err := json.Marshal(SendMail)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	dataStr := string(data)
+
+	err = g.makePOSTAPICall(resource, "application/json", dataStr, nil)
+	return err
+}
+
+// SendMailMIME performs a text/plain (in MIME format) sendMail request
+func (g *GraphClient) SendMailMIME(from string, data []byte) error {
+	resource := fmt.Sprintf("/users/%v/sendMail", url.PathEscape(from))
+	datab64 := b64.StdEncoding.EncodeToString(data)
+	err := g.makePOSTAPICall(resource, "text/plain", datab64, nil)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/open-networks/go-msgraph
+module github.com/R2D2Env/go-msgraph
 
-go 1.13
+go 1.16


### PR DESCRIPTION
Adds sendMail capability (/users/<user>/sendMail). This is done by:

- Creating a `makePOSTAPICall`  method which largely duplicates `makeGETAPICall`
- Creating a Mail.go submodule which includes the code needed to sendMail in both MIME and JSON formats.